### PR TITLE
feat(agent): add multi-provider LLM support for recaption (MiniMax, OpenAI-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,13 +186,33 @@ FireRed-Image-Edit natively supports **1–3** input images. When users need to 
 3. **Recaption** – Rewrites the user instruction so that image references (图1/图2/image N …) correctly point to the new composite images, and expands the prompt to ~512 words/characters for richer editing context. The user's original language is preserved.
 
 
-**(Optional)** To enable the **Recaption** feature (rewriting instructions via Gemini for better editing results), set your Gemini API key:
+**(Optional)** To enable the **Recaption** feature (rewriting instructions via an LLM for better editing results), set up one of the supported LLM providers:
+
+**Option 1: Gemini (default)**
 
 ```bash
 export GEMINI_API_KEY="your-gemini-api-key"
 ```
 
-> **Note:** The Gemini API is **not required**. Without it, the Agent will still perform ROI detection and image stitching normally, but will skip the instruction rewriting step. Setting a Gemini API key is recommended for best results.
+**Option 2: MiniMax**
+
+```bash
+export RECAPTION_PROVIDER="minimax"
+export MINIMAX_API_KEY="your-minimax-api-key"
+```
+
+Uses the [MiniMax](https://www.minimax.io/) OpenAI-compatible API with the `MiniMax-M2.7` model by default. You can also use `MiniMax-M2.7-highspeed` for faster responses.
+
+**Option 3: Any OpenAI-compatible API**
+
+```bash
+export RECAPTION_PROVIDER="openai_compatible"
+export OPENAI_COMPATIBLE_API_KEY="your-api-key"
+export OPENAI_COMPATIBLE_BASE_URL="https://your-api.example.com/v1"
+export OPENAI_COMPATIBLE_MODEL="your-model-name"
+```
+
+> **Note:** The LLM API is **not required** for basic usage. Without it, the Agent will still perform ROI detection and image stitching normally, but will skip the instruction rewriting step. Setting an LLM API key is recommended for best results. The ROI detection step always uses Gemini (multimodal required).
 
 
 

--- a/agent/config.py
+++ b/agent/config.py
@@ -3,10 +3,18 @@
 import os
 
 # ---------------------------------------------------------------------------
-# Gemini API
+# Gemini API (used for multimodal ROI detection; always requires Gemini)
 # ---------------------------------------------------------------------------
 GEMINI_API_KEY: str = os.environ.get("GEMINI_API_KEY", "")
 GEMINI_MODEL_NAME: str = os.environ.get("GEMINI_MODEL_NAME", "gemini-2.5-flash")
+
+# ---------------------------------------------------------------------------
+# Recaption LLM provider (text-only instruction rewriting)
+# ---------------------------------------------------------------------------
+# Supported values: "gemini" (default), "openai_compatible", "minimax"
+# When set to "minimax", uses the OpenAI-compatible provider with MiniMax
+# defaults (base URL: https://api.minimax.io/v1, model: MiniMax-M2.7).
+RECAPTION_PROVIDER: str = os.environ.get("RECAPTION_PROVIDER", "gemini")
 
 # ---------------------------------------------------------------------------
 # Image stitching defaults

--- a/agent/llm_provider.py
+++ b/agent/llm_provider.py
@@ -1,0 +1,214 @@
+"""LLM provider abstraction for text generation.
+
+Supports multiple backends for the text-only recaption step:
+
+- **gemini** (default): Uses ``google-generativeai`` SDK.
+- **openai_compatible**: Any OpenAI-compatible API (MiniMax, OpenAI, etc.).
+
+The ROI detection step (multimodal) always uses Gemini directly and is
+not affected by this provider selection.
+
+Provider selection is controlled by the ``RECAPTION_PROVIDER`` environment
+variable (default ``"gemini"``).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import traceback
+import warnings
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+# ───────────────── abstract base ──────────────────
+
+
+class LLMProvider(ABC):
+    """Abstract interface for text generation."""
+
+    @abstractmethod
+    def generate(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 4096,
+    ) -> str:
+        """Generate a text completion.
+
+        Parameters
+        ----------
+        system_prompt:
+            System-level instruction.
+        user_prompt:
+            User-level prompt / question.
+        temperature:
+            Sampling temperature.
+        max_tokens:
+            Maximum number of output tokens.
+
+        Returns
+        -------
+        The generated text (stripped).
+        """
+
+
+# ───────────────── Gemini provider ──────────────────
+
+
+class GeminiProvider(LLMProvider):
+    """Text generation via Google Gemini (``google-generativeai`` SDK)."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model_name: str | None = None,
+    ) -> None:
+        from agent.config import GEMINI_API_KEY, GEMINI_MODEL_NAME
+
+        self._api_key = api_key or GEMINI_API_KEY
+        self._model_name = model_name or GEMINI_MODEL_NAME
+
+    def _init_model(self, temperature: float, max_tokens: int) -> Any:
+        try:
+            import google.generativeai as genai
+        except ImportError as exc:
+            raise ImportError(
+                "google-generativeai is required for the Gemini provider. "
+                "Install it with:  pip install google-generativeai"
+            ) from exc
+        genai.configure(api_key=self._api_key)
+        return genai.GenerativeModel(
+            model_name=self._model_name,
+            generation_config={
+                "temperature": temperature,
+                "max_output_tokens": max_tokens,
+                "top_p": 0.95,
+            },
+        )
+
+    def generate(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 4096,
+    ) -> str:
+        model = self._init_model(temperature, max_tokens)
+        response = model.generate_content(
+            [{"role": "user", "parts": [system_prompt + "\n\n" + user_prompt]}]
+        )
+        return response.text.strip() if response.text else ""
+
+
+# ───────────────── OpenAI-compatible provider ──────────────────
+
+
+class OpenAICompatibleProvider(LLMProvider):
+    """Text generation via any OpenAI-compatible API.
+
+    Works with MiniMax, OpenAI, DeepSeek, and other providers that expose
+    a ``/v1/chat/completions`` endpoint.
+
+    Configuration is read from environment variables:
+
+    - ``OPENAI_COMPATIBLE_API_KEY`` or ``MINIMAX_API_KEY``: API key.
+    - ``OPENAI_COMPATIBLE_BASE_URL``: Base URL (default: MiniMax
+      ``https://api.minimax.io/v1``).
+    - ``OPENAI_COMPATIBLE_MODEL``: Model name (default: ``MiniMax-M2.7``).
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        model: str | None = None,
+    ) -> None:
+        self._api_key = (
+            api_key
+            or os.environ.get("OPENAI_COMPATIBLE_API_KEY")
+            or os.environ.get("MINIMAX_API_KEY", "")
+        )
+        self._base_url = (
+            base_url
+            or os.environ.get(
+                "OPENAI_COMPATIBLE_BASE_URL", "https://api.minimax.io/v1"
+            )
+        )
+        self._model = (
+            model
+            or os.environ.get("OPENAI_COMPATIBLE_MODEL", "MiniMax-M2.7")
+        )
+
+    def _get_client(self) -> Any:
+        try:
+            from openai import OpenAI
+        except ImportError as exc:
+            raise ImportError(
+                "openai package is required for the OpenAI-compatible "
+                "provider. Install it with:  pip install openai"
+            ) from exc
+        return OpenAI(api_key=self._api_key, base_url=self._base_url)
+
+    def generate(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 4096,
+    ) -> str:
+        client = self._get_client()
+        # Clamp temperature to (0, 1] for providers like MiniMax
+        temperature = max(0.01, min(temperature, 1.0))
+        response = client.chat.completions.create(
+            model=self._model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        text = response.choices[0].message.content or ""
+        # Strip thinking tags that some models (e.g. MiniMax M2.5+) may emit
+        import re
+
+        text = re.sub(
+            r"<think>.*?</think>", "", text, flags=re.DOTALL
+        ).strip()
+        return text
+
+
+# ───────────────── factory ──────────────────
+
+_PROVIDERS: dict[str, type[LLMProvider]] = {
+    "gemini": GeminiProvider,
+    "openai_compatible": OpenAICompatibleProvider,
+    "minimax": OpenAICompatibleProvider,
+}
+
+
+def get_recaption_provider() -> LLMProvider:
+    """Return the configured recaption LLM provider.
+
+    The provider is selected via the ``RECAPTION_PROVIDER`` environment
+    variable.  Accepted values: ``"gemini"`` (default),
+    ``"openai_compatible"``, ``"minimax"``.
+
+    When ``"minimax"`` is selected, the OpenAI-compatible provider is used
+    with MiniMax defaults (``https://api.minimax.io/v1``, model
+    ``MiniMax-M2.7``).
+    """
+    provider_name = os.environ.get("RECAPTION_PROVIDER", "gemini").lower()
+    provider_cls = _PROVIDERS.get(provider_name)
+    if provider_cls is None:
+        raise ValueError(
+            f"Unknown RECAPTION_PROVIDER: {provider_name!r}. "
+            f"Supported providers: {sorted(_PROVIDERS.keys())}"
+        )
+    return provider_cls()

--- a/agent/recaption.py
+++ b/agent/recaption.py
@@ -1,4 +1,4 @@
-"""Recaption module – rewrite user instructions via Gemini.
+"""Recaption module – rewrite user instructions via a configurable LLM.
 
 After N images have been grouped into 2-3 composite images, the original
 references such as "图1", "图2", …, "image 3" no longer correspond to the
@@ -9,6 +9,11 @@ that:
 2. The instruction is expanded to ~512 words / characters (matching the
    user's language) to provide richer context for FireRed-Image-Edit.
 3. The user's original language is preserved (Chinese stays Chinese, etc.).
+
+The LLM backend is selected via the ``RECAPTION_PROVIDER`` environment
+variable.  Supported values: ``"gemini"`` (default),
+``"openai_compatible"``, ``"minimax"``.  See :mod:`agent.llm_provider` for
+details.
 """
 
 from __future__ import annotations
@@ -17,42 +22,13 @@ import re
 import time
 import traceback
 import warnings
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
-from agent.config import GEMINI_API_KEY, GEMINI_MODEL_NAME, RECAPTION_TARGET_LENGTH
-
-if TYPE_CHECKING:
-    import google.generativeai as genai
+from agent.config import RECAPTION_TARGET_LENGTH
 
 # Retry settings
 _MAX_RETRIES: int = 3
 _RETRY_BACKOFF: float = 2.0  # seconds, doubled each retry
-
-
-def _import_genai():
-    """Lazily import google.generativeai with a friendly error message."""
-    try:
-        import google.generativeai as _genai
-    except ImportError as exc:
-        raise ImportError(
-            "google-generativeai is required for recaption. "
-            "Install it with:  pip install google-generativeai"
-        ) from exc
-    return _genai
-
-
-def _init_gemini() -> Any:
-    """Lazily configure the Gemini SDK and return a model instance."""
-    genai = _import_genai()
-    genai.configure(api_key=GEMINI_API_KEY)
-    return genai.GenerativeModel(
-        model_name=GEMINI_MODEL_NAME,
-        generation_config={
-            "temperature": 0.4,
-            "max_output_tokens": 4096,
-            "top_p": 0.95,
-        },
-    )
 
 
 # ───────────────── simple reference mapping ──────────────────
@@ -224,12 +200,13 @@ def recaption(
     )
 
     try:
-        model = _init_gemini()
-    except ImportError:
+        from agent.llm_provider import get_recaption_provider
+
+        provider = get_recaption_provider()
+    except (ImportError, ValueError) as exc:
         warnings.warn(
-            "[Recaption] google-generativeai is not installed. "
-            "Skipping recaption and using the original prompt. "
-            "Install it with:  pip install google-generativeai",
+            f"[Recaption] Failed to initialise LLM provider: {exc!r}. "
+            "Skipping recaption and using the original prompt.",
             RuntimeWarning,
             stacklevel=2,
         )
@@ -240,13 +217,13 @@ def recaption(
     last_exc: Exception | None = None
     for attempt in range(1, _MAX_RETRIES + 1):
         try:
-            response = model.generate_content(
-                [
-                    {"role": "user", "parts": [system_prompt + "\n\n" + user_prompt]},
-                ]
+            rewritten = provider.generate(
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                temperature=0.4,
+                max_tokens=4096,
             )
-            rewritten = response.text.strip() if response.text else instruction_fixed
-            return rewritten
+            return rewritten if rewritten else instruction_fixed
         except Exception as exc:
             last_exc = exc
             traceback.print_exc()
@@ -260,7 +237,7 @@ def recaption(
 
     # All retries exhausted – warn and fall back to the original prompt.
     warnings.warn(
-        f"[Recaption] Gemini API call failed after {_MAX_RETRIES} attempts. "
+        f"[Recaption] LLM call failed after {_MAX_RETRIES} attempts. "
         f"Last error: {last_exc!r}. "
         f"Falling back to the original prompt for inference.",
         RuntimeWarning,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ google-generativeai
 tqdm
 cache_dit
 optimum-quanto
+openai  # Optional: required for MiniMax / OpenAI-compatible recaption providers

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,121 @@
+"""Integration tests for LLM provider with real API calls.
+
+These tests require valid API keys and network access. They are skipped
+by default unless the appropriate environment variables are set:
+
+- ``MINIMAX_API_KEY``: Required for MiniMax integration tests.
+- ``GEMINI_API_KEY``: Required for Gemini integration tests.
+- ``RUN_INTEGRATION_TESTS=1``: Must be set to enable integration tests.
+
+Run with::
+
+    RUN_INTEGRATION_TESTS=1 MINIMAX_API_KEY=... pytest tests/test_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO not in sys.path:
+    sys.path.insert(0, _REPO)
+
+_SKIP_INTEGRATION = os.environ.get("RUN_INTEGRATION_TESTS") != "1"
+
+
+@pytest.mark.skipif(_SKIP_INTEGRATION, reason="RUN_INTEGRATION_TESTS not set")
+class TestMiniMaxIntegration:
+    """Integration tests using real MiniMax API."""
+
+    @pytest.fixture(autouse=True)
+    def _require_key(self):
+        if not os.environ.get("MINIMAX_API_KEY"):
+            pytest.skip("MINIMAX_API_KEY not set")
+
+    def test_minimax_provider_generate(self):
+        from agent.llm_provider import OpenAICompatibleProvider
+
+        provider = OpenAICompatibleProvider(
+            api_key=os.environ["MINIMAX_API_KEY"],
+            base_url="https://api.minimax.io/v1",
+            model="MiniMax-M2.7",
+        )
+        result = provider.generate(
+            system_prompt="You are a helpful assistant.",
+            user_prompt="Reply with exactly: HELLO",
+            temperature=0.01,
+            max_tokens=64,
+        )
+        assert len(result) > 0
+        assert "HELLO" in result.upper()
+
+    def test_minimax_recaption_end_to_end(self):
+        from agent.recaption import recaption
+
+        with (
+            os.environ.__class__.__mro__[0].__init__
+            and False
+            or True
+        ) and \
+        pytest.MonkeyPatch().context() as mp:
+            mp.setenv("RECAPTION_PROVIDER", "minimax")
+            mp.setenv("MINIMAX_API_KEY", os.environ["MINIMAX_API_KEY"])
+            result = recaption(
+                "将图2的猫放到图1的背景上",
+                [[0], [1]],
+                target_length=128,
+            )
+            # Should return a non-empty rewritten instruction
+            assert len(result) > 10
+            # Original intent should be preserved
+            assert any(c in result for c in ["猫", "cat", "背景", "background"])
+
+    def test_minimax_temperature_boundaries(self):
+        from agent.llm_provider import OpenAICompatibleProvider
+
+        provider = OpenAICompatibleProvider(
+            api_key=os.environ["MINIMAX_API_KEY"],
+            base_url="https://api.minimax.io/v1",
+            model="MiniMax-M2.7",
+        )
+        # Should not raise with edge temperature values
+        result = provider.generate(
+            system_prompt="Reply briefly.",
+            user_prompt="Say OK",
+            temperature=0.01,
+            max_tokens=256,
+        )
+        assert len(result) > 0
+
+
+@pytest.mark.skipif(_SKIP_INTEGRATION, reason="RUN_INTEGRATION_TESTS not set")
+class TestGeminiIntegration:
+    """Integration tests using real Gemini API."""
+
+    @pytest.fixture(autouse=True)
+    def _require_key(self):
+        if not os.environ.get("GEMINI_API_KEY"):
+            pytest.skip("GEMINI_API_KEY not set")
+
+    def test_gemini_provider_generate(self):
+        from agent.llm_provider import GeminiProvider
+
+        provider = GeminiProvider(
+            api_key=os.environ["GEMINI_API_KEY"],
+            model_name="gemini-2.5-flash",
+        )
+        result = provider.generate(
+            system_prompt="You are a helpful assistant.",
+            user_prompt="Reply with exactly: HELLO",
+            temperature=0.1,
+            max_tokens=64,
+        )
+        assert len(result) > 0
+        assert "HELLO" in result.upper()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,371 @@
+"""Unit tests for agent.llm_provider and agent.recaption with provider support."""
+
+from __future__ import annotations
+
+import os
+import re
+import types
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import helpers – the agent package may not be on sys.path by default
+# ---------------------------------------------------------------------------
+import sys
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO not in sys.path:
+    sys.path.insert(0, _REPO)
+
+from agent.llm_provider import (
+    GeminiProvider,
+    LLMProvider,
+    OpenAICompatibleProvider,
+    get_recaption_provider,
+)
+from agent.recaption import (
+    _replace_image_refs,
+    build_reference_map,
+    recaption,
+)
+
+
+# ===================================================================
+# Tests for build_reference_map
+# ===================================================================
+
+
+class TestBuildReferenceMap:
+    def test_single_group(self):
+        assert build_reference_map([[0, 1, 2]]) == {1: 1, 2: 1, 3: 1}
+
+    def test_two_groups(self):
+        assert build_reference_map([[0, 1], [2, 3]]) == {
+            1: 1, 2: 1, 3: 2, 4: 2,
+        }
+
+    def test_three_groups(self):
+        result = build_reference_map([[0], [1, 2], [3, 4, 5]])
+        assert result == {1: 1, 2: 2, 3: 2, 4: 3, 5: 3, 6: 3}
+
+    def test_empty(self):
+        assert build_reference_map([]) == {}
+
+
+# ===================================================================
+# Tests for _replace_image_refs
+# ===================================================================
+
+
+class TestReplaceImageRefs:
+    def test_chinese_refs(self):
+        ref_map = {1: 1, 2: 1, 3: 2}
+        text = "将图2的猫放到图3的背景上"
+        result = _replace_image_refs(text, ref_map)
+        assert result == "将图1的猫放到图2的背景上"
+
+    def test_english_refs(self):
+        ref_map = {1: 1, 2: 1, 3: 2}
+        text = "Place image 2 onto image 3"
+        result = _replace_image_refs(text, ref_map)
+        assert result == "Place image 1 onto image 2"
+
+    def test_img_abbreviation(self):
+        ref_map = {1: 1, 2: 2}
+        text = "Merge img1 with IMG 2"
+        result = _replace_image_refs(text, ref_map)
+        assert result == "Merge img1 with IMG 2"
+
+    def test_ordinal_chinese(self):
+        ref_map = {1: 1, 2: 1, 3: 2}
+        text = "将第3张图的背景换成蓝天"
+        result = _replace_image_refs(text, ref_map)
+        assert result == "将第2张图的背景换成蓝天"
+
+    def test_no_mapping(self):
+        ref_map = {1: 1}
+        text = "图5的风格"
+        result = _replace_image_refs(text, ref_map)
+        # image 5 not in map → stays as-is
+        assert result == "图5的风格"
+
+    def test_empty_text(self):
+        assert _replace_image_refs("", {1: 1}) == ""
+
+
+# ===================================================================
+# Tests for LLMProvider abstraction
+# ===================================================================
+
+
+class TestLLMProviderABC:
+    def test_cannot_instantiate(self):
+        with pytest.raises(TypeError):
+            LLMProvider()
+
+    def test_subclass_must_implement_generate(self):
+        class BadProvider(LLMProvider):
+            pass
+
+        with pytest.raises(TypeError):
+            BadProvider()
+
+
+# ===================================================================
+# Tests for GeminiProvider
+# ===================================================================
+
+
+class TestGeminiProvider:
+    def test_init_uses_config_defaults(self):
+        with mock.patch("agent.config.GEMINI_API_KEY", "test-key"):
+            provider = GeminiProvider()
+            assert provider._api_key == "test-key"
+
+    def test_init_with_explicit_params(self):
+        provider = GeminiProvider(api_key="my-key", model_name="gemini-pro")
+        assert provider._api_key == "my-key"
+        assert provider._model_name == "gemini-pro"
+
+    def test_generate_calls_gemini(self):
+        provider = GeminiProvider(api_key="k", model_name="m")
+
+        mock_response = mock.MagicMock()
+        mock_response.text = "  rewritten instruction  "
+
+        mock_model = mock.MagicMock()
+        mock_model.generate_content.return_value = mock_response
+
+        mock_genai = mock.MagicMock()
+        mock_genai.GenerativeModel.return_value = mock_model
+
+        with mock.patch.dict("sys.modules", {"google.generativeai": mock_genai}):
+            result = provider.generate("sys", "user")
+            assert result == "rewritten instruction"
+            mock_model.generate_content.assert_called_once()
+
+
+# ===================================================================
+# Tests for OpenAICompatibleProvider
+# ===================================================================
+
+
+class TestOpenAICompatibleProvider:
+    def test_defaults_to_minimax(self):
+        with mock.patch.dict(os.environ, {"MINIMAX_API_KEY": "mm-key"}, clear=False):
+            os.environ.pop("OPENAI_COMPATIBLE_API_KEY", None)
+            os.environ.pop("OPENAI_COMPATIBLE_BASE_URL", None)
+            os.environ.pop("OPENAI_COMPATIBLE_MODEL", None)
+            provider = OpenAICompatibleProvider()
+            assert provider._api_key == "mm-key"
+            assert "minimax" in provider._base_url.lower()
+            assert provider._model == "MiniMax-M2.7"
+
+    def test_explicit_params(self):
+        provider = OpenAICompatibleProvider(
+            api_key="k", base_url="http://localhost", model="test-model"
+        )
+        assert provider._api_key == "k"
+        assert provider._base_url == "http://localhost"
+        assert provider._model == "test-model"
+
+    def test_env_override(self):
+        env = {
+            "OPENAI_COMPATIBLE_API_KEY": "oc-key",
+            "OPENAI_COMPATIBLE_BASE_URL": "https://custom.api/v1",
+            "OPENAI_COMPATIBLE_MODEL": "custom-model",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            provider = OpenAICompatibleProvider()
+            assert provider._api_key == "oc-key"
+            assert provider._base_url == "https://custom.api/v1"
+            assert provider._model == "custom-model"
+
+    def test_temperature_clamping(self):
+        provider = OpenAICompatibleProvider(api_key="k", base_url="http://x", model="m")
+
+        mock_choice = mock.MagicMock()
+        mock_choice.message.content = "output"
+
+        mock_response = mock.MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = mock.MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+
+        mock_openai = mock.MagicMock()
+        mock_openai.return_value = mock_client
+
+        with mock.patch("agent.llm_provider.OpenAICompatibleProvider._get_client", return_value=mock_client):
+            # Temperature 0.0 should be clamped to 0.01
+            provider.generate("sys", "user", temperature=0.0)
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert call_kwargs["temperature"] == pytest.approx(0.01)
+
+            # Temperature 1.5 should be clamped to 1.0
+            provider.generate("sys", "user", temperature=1.5)
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert call_kwargs["temperature"] == pytest.approx(1.0)
+
+    def test_strips_think_tags(self):
+        provider = OpenAICompatibleProvider(api_key="k", base_url="http://x", model="m")
+
+        mock_choice = mock.MagicMock()
+        mock_choice.message.content = "<think>reasoning here</think>actual output"
+
+        mock_response = mock.MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = mock.MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with mock.patch("agent.llm_provider.OpenAICompatibleProvider._get_client", return_value=mock_client):
+            result = provider.generate("sys", "user")
+            assert result == "actual output"
+            assert "<think>" not in result
+
+
+# ===================================================================
+# Tests for get_recaption_provider factory
+# ===================================================================
+
+
+class TestGetRecaptionProvider:
+    def test_default_is_gemini(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("RECAPTION_PROVIDER", None)
+            provider = get_recaption_provider()
+            assert isinstance(provider, GeminiProvider)
+
+    def test_gemini_explicit(self):
+        with mock.patch.dict(os.environ, {"RECAPTION_PROVIDER": "gemini"}):
+            provider = get_recaption_provider()
+            assert isinstance(provider, GeminiProvider)
+
+    def test_openai_compatible(self):
+        with mock.patch.dict(os.environ, {"RECAPTION_PROVIDER": "openai_compatible"}):
+            provider = get_recaption_provider()
+            assert isinstance(provider, OpenAICompatibleProvider)
+
+    def test_minimax(self):
+        with mock.patch.dict(os.environ, {"RECAPTION_PROVIDER": "minimax"}):
+            provider = get_recaption_provider()
+            assert isinstance(provider, OpenAICompatibleProvider)
+
+    def test_case_insensitive(self):
+        with mock.patch.dict(os.environ, {"RECAPTION_PROVIDER": "MiniMax"}):
+            provider = get_recaption_provider()
+            assert isinstance(provider, OpenAICompatibleProvider)
+
+    def test_unknown_provider_raises(self):
+        with mock.patch.dict(os.environ, {"RECAPTION_PROVIDER": "unknown"}):
+            with pytest.raises(ValueError, match="Unknown RECAPTION_PROVIDER"):
+                get_recaption_provider()
+
+
+# ===================================================================
+# Tests for recaption() with provider integration
+# ===================================================================
+
+
+class TestRecaptionWithProvider:
+    def test_recaption_uses_provider(self):
+        """recaption() should use the configured provider for generation."""
+        mock_provider = mock.MagicMock(spec=LLMProvider)
+        mock_provider.generate.return_value = "Rewritten instruction"
+
+        with mock.patch(
+            "agent.llm_provider.get_recaption_provider", return_value=mock_provider
+        ):
+            result = recaption("Edit image 1", [[0], [1]])
+            assert result == "Rewritten instruction"
+            mock_provider.generate.assert_called_once()
+
+    def test_recaption_fallback_on_provider_error(self):
+        """When provider init fails, recaption should fall back to regex-only."""
+        with mock.patch(
+            "agent.llm_provider.get_recaption_provider",
+            side_effect=ImportError("no provider"),
+        ):
+            result = recaption("Edit 图2", [[0, 1]])
+            # 图2 → 图1 (regex pass), no LLM expansion
+            assert "图1" in result
+
+    def test_recaption_fallback_on_generate_error(self):
+        """When generate() fails all retries, fall back to regex-fixed text."""
+        mock_provider = mock.MagicMock(spec=LLMProvider)
+        mock_provider.generate.side_effect = RuntimeError("API down")
+
+        with mock.patch(
+            "agent.llm_provider.get_recaption_provider", return_value=mock_provider
+        ), mock.patch("agent.recaption._RETRY_BACKOFF", 0):
+            result = recaption("Edit 图3", [[0, 1, 2]])
+            # Should fall back after 3 retries
+            assert "图1" in result
+            assert mock_provider.generate.call_count == 3
+
+    def test_recaption_empty_response_uses_fallback(self):
+        """When provider returns empty string, use the regex-fixed instruction."""
+        mock_provider = mock.MagicMock(spec=LLMProvider)
+        mock_provider.generate.return_value = ""
+
+        with mock.patch(
+            "agent.llm_provider.get_recaption_provider", return_value=mock_provider
+        ):
+            result = recaption("Edit 图2", [[0, 1]])
+            assert "图1" in result
+
+
+# ===================================================================
+# Tests for OpenAICompatibleProvider message format
+# ===================================================================
+
+
+class TestOpenAICompatibleMessageFormat:
+    def test_system_and_user_messages(self):
+        provider = OpenAICompatibleProvider(api_key="k", base_url="http://x", model="m")
+
+        mock_choice = mock.MagicMock()
+        mock_choice.message.content = "output"
+        mock_response = mock.MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_client = mock.MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with mock.patch("agent.llm_provider.OpenAICompatibleProvider._get_client", return_value=mock_client):
+            provider.generate("system prompt", "user prompt")
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            messages = call_kwargs["messages"]
+            assert len(messages) == 2
+            assert messages[0]["role"] == "system"
+            assert messages[0]["content"] == "system prompt"
+            assert messages[1]["role"] == "user"
+            assert messages[1]["content"] == "user prompt"
+
+
+# ===================================================================
+# Tests for config module
+# ===================================================================
+
+
+class TestConfig:
+    def test_recaption_provider_default(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("RECAPTION_PROVIDER", None)
+            # Re-import to get fresh value
+            import importlib
+            import agent.config
+            importlib.reload(agent.config)
+            assert agent.config.RECAPTION_PROVIDER == "gemini"
+
+    def test_recaption_provider_env(self):
+        with mock.patch.dict(os.environ, {"RECAPTION_PROVIDER": "minimax"}):
+            import importlib
+            import agent.config
+            importlib.reload(agent.config)
+            assert agent.config.RECAPTION_PROVIDER == "minimax"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

This PR adds a pluggable LLM provider system for the **recaption** (instruction rewriting) step in the Agent pipeline, enabling users to choose between **Gemini**, **MiniMax**, or any **OpenAI-compatible** API.

### Changes

- **New `agent/llm_provider.py`**: Abstract `LLMProvider` base class with concrete implementations:
  - `GeminiProvider` — wraps the existing `google-generativeai` SDK
  - `OpenAICompatibleProvider` — works with MiniMax, OpenAI, DeepSeek, and any `/v1/chat/completions` endpoint
- **Updated `agent/recaption.py`**: Uses the provider abstraction instead of direct Gemini calls; graceful fallback on provider init/API errors
- **Updated `agent/config.py`**: New `RECAPTION_PROVIDER` env var (default: `"gemini"`)
- **Updated `README.md`**: Multi-provider setup instructions (Gemini, MiniMax, custom OpenAI-compatible)
- **33 unit tests + 3 integration tests** covering provider factory, temperature clamping, think-tag stripping, fallback behavior, and live MiniMax API calls

### Provider selection

```bash
# Gemini (default, same as before)
export GEMINI_API_KEY="your-key"

# MiniMax
export RECAPTION_PROVIDER="minimax"
export MINIMAX_API_KEY="your-key"

# Any OpenAI-compatible API
export RECAPTION_PROVIDER="openai_compatible"
export OPENAI_COMPATIBLE_API_KEY="your-key"
export OPENAI_COMPATIBLE_BASE_URL="https://your-api/v1"
export OPENAI_COMPATIBLE_MODEL="model-name"
```

### Design decisions

- **ROI detection stays Gemini-only**: It requires multimodal (sending images), which text-only providers like MiniMax cannot support
- **Backward compatible**: Default provider is `"gemini"` — existing users see no change
- **MiniMax-specific handling**: Temperature clamping to `(0, 1]` and automatic `<think>` tag stripping

## Test plan

- [x] 33 unit tests pass (`pytest tests/test_llm_provider.py`)
- [x] 3 MiniMax integration tests pass with live API
- [x] Existing recaption behavior preserved (Gemini provider path)
- [ ] Verify with Gemini API key (requires `GEMINI_API_KEY`)
